### PR TITLE
Use `.getHeaders()` instead of `._headers`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (req, time) {
 
 	var delays = isNaN(time) ? time : {socket: time, connect: time};
 	var host = req.getHeaders ?
-	    		(' to ' + req.getHeaders().host) :
+			(' to ' + req.getHeaders().host) :
 			req._headers ?
 				(' to ' + req._headers.host) :
 				'';

--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ module.exports = function (req, time) {
 	}
 
 	var delays = isNaN(time) ? time : {socket: time, connect: time};
-	var host = req._headers ? (' to ' + req._headers.host) : '';
+	var host = req.getHeaders
+                     ? (' to ' + req.getHeaders().host)
+                     : req._headers
+                       ? (' to ' + req._headers.host)
+                       : '';
 
 	if (delays.connect !== undefined) {
 		req.timeoutTimer = setTimeout(function timeoutHandler() {

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ module.exports = function (req, time) {
 	}
 
 	var delays = isNaN(time) ? time : {socket: time, connect: time};
-	var host = req.getHeaders
-                     ? (' to ' + req.getHeaders().host)
-                     : req._headers
-                       ? (' to ' + req._headers.host)
-                       : '';
+	var host = req.getHeaders ?
+	    		(' to ' + req.getHeaders().host) :
+			req._headers ?
+				(' to ' + req._headers.host) :
+				'';
 
 	if (delays.connect !== undefined) {
 		req.timeoutTimer = setTimeout(function timeoutHandler() {


### PR DESCRIPTION
[DEP0066] OutgoingMessage.prototype._headers is deprecated